### PR TITLE
Make the plugin compatible with Redmine 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,2 @@
 gem 'ruby-filemagic'
+gem 'marcel'

--- a/init.rb
+++ b/init.rb
@@ -33,7 +33,7 @@ Redmine::Plugin.register :redmine_preview_pdf do
   name 'Redmine Preview PDF'
   author 'Stephan Wenzel'
   description 'This is a plugin for Redmine to preview a pdf attachment file'
-  version '1.1.4'
+  version '1.0.5'
   url 'https://github.com/HugoHasenbein/redmine_preview_pdf'
   author_url 'https://github.com/HugoHasenbein/redmine_preview_pdf'
 

--- a/init.rb
+++ b/init.rb
@@ -33,7 +33,7 @@ Redmine::Plugin.register :redmine_preview_pdf do
   name 'Redmine Preview PDF'
   author 'Stephan Wenzel'
   description 'This is a plugin for Redmine to preview a pdf attachment file'
-  version '1.0.4'
+  version '1.1.4'
   url 'https://github.com/HugoHasenbein/redmine_preview_pdf'
   author_url 'https://github.com/HugoHasenbein/redmine_preview_pdf'
 

--- a/lib/redmine_preview_pdf/patches/admin_controller_patch.rb
+++ b/lib/redmine_preview_pdf/patches/admin_controller_patch.rb
@@ -28,8 +28,9 @@ module RedminePreviewPdf
 
         base.class_eval do
           unloadable
-            
-          alias_method_chain :info, :gs_for_preview_pdf
+
+          alias_method :info_without_gs_for_preview_pdf, :info
+          alias_method :info, :info_with_gs_for_preview_pdf
           
         end #base
         

--- a/lib/redmine_preview_pdf/patches/attachments_controller_patch.rb
+++ b/lib/redmine_preview_pdf/patches/attachments_controller_patch.rb
@@ -44,7 +44,7 @@ module RedminePreviewPdf
 				# anymore - therefore, we must check individually, which file format the thumbnail has
 				#
 				mime_type = ""
-				File.open(preview) {|f| mime_type = MimeMagic.by_magic(f).try(:type) }
+				File.open(preview) {|f| mime_type = Marcel::MimeType.for(f)}
 				preview_filename   = File.basename(@attachment.filename, File.extname(@attachment.filename))
 				preview_filename  += Rack::Mime::MIME_TYPES.invert[mime_type] 
 

--- a/lib/redmine_preview_pdf/patches/attachments_controller_patch.rb
+++ b/lib/redmine_preview_pdf/patches/attachments_controller_patch.rb
@@ -75,6 +75,7 @@ module RedminePreviewPdf
                 rendered = true
               end
             }
+            format.api
           end
           
           show_without_pdf unless rendered 

--- a/lib/redmine_preview_pdf/patches/attachments_controller_patch.rb
+++ b/lib/redmine_preview_pdf/patches/attachments_controller_patch.rb
@@ -28,8 +28,9 @@ module RedminePreviewPdf
 
         base.class_eval do
           unloadable
-            
-          alias_method_chain     :show, :pdf
+
+          alias_method :show_without_pdf, :show
+          alias_method :show, :show_with_pdf
          
           alias_method           :find_attachment_for_preview, :find_attachment
           before_action          :find_attachment_for_preview, :only => [:preview_pdf]

--- a/lib/redmine_preview_pdf/patches/thumbnail_patch.rb
+++ b/lib/redmine_preview_pdf/patches/thumbnail_patch.rb
@@ -45,7 +45,7 @@ module RedminePreviewPdf
 			unless File.exists?(target)
 
 			  mime_type = ""
-			  unless File.open(source) {|f| mime_type = MimeMagic.by_magic(f).try(:type); @REDMINE_PREVIEW_PDF_ALLOWED_TYPES.include? mime_type }
+			  unless File.open(source) {|f| mime_type = Marcel::MimeType.for(f); @REDMINE_PREVIEW_PDF_ALLOWED_TYPES.include? mime_type }
 				return nil
 			  end
 


### PR DESCRIPTION
Hello. Thank you for this great plugin.
Here is a simple patch which make the plugin compatible with the last versions of Redmine.

The method alias_method_chain has been removed from Rails 5. But we can still alias methods.

With these changes, the plugin works well on Redmine 4, but is still fully compatible with Redmine 3.